### PR TITLE
습득물 게시판 레이아웃 수정

### DIFF
--- a/src/asset/constant.ts
+++ b/src/asset/constant.ts
@@ -21,4 +21,5 @@ export const STATIC_URL = {
   ITEM: `https://user-images.githubusercontent.com/46309902/119210128-a09f3e80-bae5-11eb-9ca6-0c7aff8b3a41.png`,
   WHITE_PLUS_ICON: `https://user-images.githubusercontent.com/46309902/129130829-4d342427-719b-4bc6-9f2c-f0fbdae92689.png`,
   SEARCH: `https://user-images.githubusercontent.com/46309902/129131150-946eb4c8-48f9-4cf7-9aef-18bdc58bf0cc.png`,
+  CLOSE: `https://user-images.githubusercontent.com/46309902/129339675-68bfa4f4-4f6e-4b9d-9828-784964c188f0.png`,
 };

--- a/src/asset/constant.ts
+++ b/src/asset/constant.ts
@@ -19,4 +19,6 @@ export const STATIC_URL = {
   WARN: `https://user-images.githubusercontent.com/46309902/119188852-3ae78e00-bab6-11eb-9781-246121926a09.png`,
   LOCATION: `https://user-images.githubusercontent.com/46309902/119208441-2965ac80-badd-11eb-963d-323f1d829af1.png`,
   ITEM: `https://user-images.githubusercontent.com/46309902/119210128-a09f3e80-bae5-11eb-9ca6-0c7aff8b3a41.png`,
+  WHITE_PLUS_ICON: `https://user-images.githubusercontent.com/46309902/129130829-4d342427-719b-4bc6-9f2c-f0fbdae92689.png`,
+  SEARCH: `https://user-images.githubusercontent.com/46309902/129131150-946eb4c8-48f9-4cf7-9aef-18bdc58bf0cc.png`,
 };

--- a/src/common/endpoints.ts
+++ b/src/common/endpoints.ts
@@ -1,5 +1,6 @@
 const endpoints = {
   API_BASE_URL: "http://127.0.0.1:8000/api",
+  FOUND_BOARD_API: "/found/board",
 };
 
 export default endpoints;

--- a/src/common/lib/api/found-board.ts
+++ b/src/common/lib/api/found-board.ts
@@ -1,0 +1,14 @@
+import axios from "../axios";
+import endpoints from "../../endpoints";
+import { FoundPostListModel } from "../../model/found-post-list";
+
+const foundBoardAPI = {
+  getPostList: async (page: number): Promise<FoundPostListModel> => {
+    const { data: postList } = await axios.get<FoundPostListModel>(
+      `${endpoints.FOUND_BOARD_API}/list?page_num=${page}`
+    );
+    return postList;
+  },
+};
+
+export default foundBoardAPI;

--- a/src/common/model/found-post-list.ts
+++ b/src/common/model/found-post-list.ts
@@ -1,0 +1,5 @@
+import { FoundPostModel } from "../model/found-post";
+
+export interface FoundPostListModel {
+  data: FoundPostModel[];
+}

--- a/src/common/model/found-post.ts
+++ b/src/common/model/found-post.ts
@@ -1,0 +1,13 @@
+export interface FoundPostModel {
+  id: number;
+  title: string;
+  item_name: string;
+  get_place: string;
+  put_place: string;
+  content: string;
+  reply_num: number;
+  created_at: string;
+  changed_at: string;
+  user_id: number;
+  image_url: string;
+}

--- a/src/component/found-post-preview/index.tsx
+++ b/src/component/found-post-preview/index.tsx
@@ -7,9 +7,12 @@ const FoundPostPreview = (props: FoundPostPreviewProps) => {
   const { title, item, location, image, replyCount } = props;
   return (
     <S.FoundPostPreview>
-      <S.Title>
-        {title} ({replyCount})
-      </S.Title>
+      <S.TitleContainer>
+        <S.Title>{title}</S.Title>
+        <S.ReplyContainer>
+          <S.Reply>{replyCount}</S.Reply>
+        </S.ReplyContainer>
+      </S.TitleContainer>
       <S.Contents>
         <S.ItemInfo>
           <S.ItemContainer>

--- a/src/component/found-post-preview/styles.ts
+++ b/src/component/found-post-preview/styles.ts
@@ -1,16 +1,24 @@
 import styled from "styled-components";
+import { THEME_COLOR } from "../../asset/constant";
 
 export const FoundPostPreview = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  width: 100%;
+  justify-content: space-evenly;
+  width: 95%;
   height: 8rem;
+  margin: 0.5rem;
   padding: 1rem;
-  border-bottom: 2px solid lightgray;
+  background-color: white;
+  border-radius: 1rem;
+  box-shadow: 0.1rem 0.1rem 0.2rem 0.05rem ${THEME_COLOR.DARK_VIOLET};
 `;
 
 export const Title = styled.div`
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-size: 1.2rem;
   font-weight: bold;
 `;
@@ -19,7 +27,6 @@ export const Contents = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.5rem 0rem;
 `;
 
 export const ItemInfo = styled.div`
@@ -30,6 +37,7 @@ export const ItemInfo = styled.div`
 
 export const ItemContainer = styled.div`
   display: flex;
+  justify-content: flex-start;
   margin-bottom: 0.5rem;
 `;
 
@@ -45,7 +53,7 @@ export const Item = styled.div`
 
 export const LocationContainer = styled.div`
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
 `;
 
 export const Location = styled.div`

--- a/src/component/found-post-preview/styles.ts
+++ b/src/component/found-post-preview/styles.ts
@@ -14,13 +14,36 @@ export const FoundPostPreview = styled.div`
   box-shadow: 0.1rem 0.1rem 0.2rem 0.05rem ${THEME_COLOR.DARK_VIOLET};
 `;
 
-export const Title = styled.div`
+export const TitleContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   width: 100%;
+  height: 1.7rem;
+  font-weight: bold;
+`;
+
+export const Title = styled.div`
+  width: 85%;
+  font-size: 1.2rem;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 1.2rem;
-  font-weight: bold;
+`;
+
+export const ReplyContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 1.7rem;
+  height: 1.7rem;
+  background-color: #d3d8f0;
+  border-radius: 50%;
+`;
+
+export const Reply = styled.div`
+  font-size: 1rem;
+  color: ${THEME_COLOR.DARK_VIOLET};
 `;
 
 export const Contents = styled.div`
@@ -63,5 +86,5 @@ export const Location = styled.div`
 export const Image = styled.img`
   height: 3.5rem;
   width: 3.5rem;
-  margin-right: 1rem;
+  /* margin-right: 1rem; */
 `;

--- a/src/container/found-board-container/index.tsx
+++ b/src/container/found-board-container/index.tsx
@@ -8,11 +8,16 @@ import { STATIC_URL } from "../../asset/constant";
 const FoundBoardContainer = () => {
   const [page, setPage] = useState(1);
   const [data, setData] = useState([] as FoundPostModel[]);
+  const [searchClicked, setSearchClicked] = useState(false);
 
   const getPostList = async (page: number) => {
     const result = await foundBoardAPI.getPostList(page);
     const data = result.data;
     setData(data);
+  };
+
+  const toggleSearch = () => {
+    setSearchClicked(!searchClicked);
   };
 
   useEffect(() => {
@@ -22,7 +27,19 @@ const FoundBoardContainer = () => {
   return (
     <S.FoundBoardContainer>
       <S.CategoryContainer>
-        <S.Category>습득물</S.Category>
+        <S.Category searchClicked={searchClicked}>습득물</S.Category>
+        <S.SearchContainer searchClicked={searchClicked}>
+          <S.SearchIcon src={STATIC_URL.SEARCH} onClick={toggleSearch} />
+          <S.SearchInput
+            searchClicked={searchClicked}
+            placeholder="검색어를 입력해 주세요"
+          />
+          <S.CloseIcon
+            searchClicked={searchClicked}
+            src={STATIC_URL.CLOSE}
+            onClick={toggleSearch}
+          />
+        </S.SearchContainer>
       </S.CategoryContainer>
       <S.PostContainer>
         {data &&

--- a/src/container/found-board-container/index.tsx
+++ b/src/container/found-board-container/index.tsx
@@ -44,7 +44,7 @@ const FoundBoardContainer = () => {
       <S.PostContainer>
         {data &&
           data.map((post, idx) => {
-            const { title, item_name, get_place, reply_num } = post;
+            const { title, item_name, get_place, reply_num, image_url } = post;
             return (
               <FoundPostPreview
                 key={idx}
@@ -52,6 +52,7 @@ const FoundBoardContainer = () => {
                 item={item_name}
                 location={get_place}
                 replyCount={reply_num}
+                image={image_url}
               />
             );
           })}

--- a/src/container/found-board-container/index.tsx
+++ b/src/container/found-board-container/index.tsx
@@ -1,35 +1,39 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import * as S from "./styles";
 import FoundPostPreview from "../../component/found-post-preview";
+import foundBoardAPI from "../../common/lib/api/found-board";
+import { FoundPostModel } from "../../common/model/found-post";
 
 const FoundBoardContainer = () => {
+  const [page, setPage] = useState(1);
+  const [data, setData] = useState([] as FoundPostModel[]);
+
+  const getPostList = async (page: number) => {
+    const result = await foundBoardAPI.getPostList(page);
+    const data = result.data;
+    setData(data);
+  };
+
+  useEffect(() => {
+    getPostList(page);
+  }, [page]);
+
   return (
     <S.FoundBoardContainer>
       <S.Category>습득물</S.Category>
-      <FoundPostPreview
-        title={"미래관 3층에서 지갑을 찾았어요"}
-        item={"지갑"}
-        location={"미래관"}
-        replyCount={5}
-      />
-      <FoundPostPreview
-        title={"미래관 3층에 에어팟 놔두고 가신 분"}
-        item={"에어팟"}
-        location={"미래관"}
-        image={
-          "https://user-images.githubusercontent.com/46309902/119209525-143f4c80-bae2-11eb-8053-14a5d09853c6.PNG"
-        }
-        replyCount={5}
-      />
-      <FoundPostPreview
-        title={"초록색 공룡 그려진 에어팟 케이스"}
-        item={"에어팟"}
-        location={"미래관"}
-        image={
-          "https://user-images.githubusercontent.com/46309902/119209525-143f4c80-bae2-11eb-8053-14a5d09853c6.PNG"
-        }
-        replyCount={5}
-      />
+      {data &&
+        data.map((post, idx) => {
+          const { title, item_name, get_place, reply_num } = post;
+          return (
+            <FoundPostPreview
+              key={idx}
+              title={title}
+              item={item_name}
+              location={get_place}
+              replyCount={reply_num}
+            />
+          );
+        })}
     </S.FoundBoardContainer>
   );
 };

--- a/src/container/found-board-container/index.tsx
+++ b/src/container/found-board-container/index.tsx
@@ -3,6 +3,7 @@ import * as S from "./styles";
 import FoundPostPreview from "../../component/found-post-preview";
 import foundBoardAPI from "../../common/lib/api/found-board";
 import { FoundPostModel } from "../../common/model/found-post";
+import { STATIC_URL } from "../../asset/constant";
 
 const FoundBoardContainer = () => {
   const [page, setPage] = useState(1);
@@ -20,20 +21,27 @@ const FoundBoardContainer = () => {
 
   return (
     <S.FoundBoardContainer>
-      <S.Category>습득물</S.Category>
-      {data &&
-        data.map((post, idx) => {
-          const { title, item_name, get_place, reply_num } = post;
-          return (
-            <FoundPostPreview
-              key={idx}
-              title={title}
-              item={item_name}
-              location={get_place}
-              replyCount={reply_num}
-            />
-          );
-        })}
+      <S.CategoryContainer>
+        <S.Category>습득물</S.Category>
+      </S.CategoryContainer>
+      <S.PostContainer>
+        {data &&
+          data.map((post, idx) => {
+            const { title, item_name, get_place, reply_num } = post;
+            return (
+              <FoundPostPreview
+                key={idx}
+                title={title}
+                item={item_name}
+                location={get_place}
+                replyCount={reply_num}
+              />
+            );
+          })}
+        <S.WriteButton>
+          <S.PlusIcon src={STATIC_URL.WHITE_PLUS_ICON} />
+        </S.WriteButton>
+      </S.PostContainer>
     </S.FoundBoardContainer>
   );
 };

--- a/src/container/found-board-container/styles.ts
+++ b/src/container/found-board-container/styles.ts
@@ -11,20 +11,59 @@ export const FoundBoardContainer = styled.div`
 
 export const CategoryContainer = styled.div`
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
   width: 100%;
   height: 3rem;
-  padding: 0rem 2rem;
+  padding: 0rem 1rem;
 `;
 
-export const Category = styled.div`
+interface SearchProps {
+  searchClicked: boolean;
+}
+
+export const Category = styled.div<SearchProps>`
   display: flex;
-  justify-content: center;
-  align-items: center;
   color: ${THEME_COLOR.DARK_VIOLET};
   font-size: 1.2rem;
   font-weight: bold;
+  transition-delay: 0.3s;
+`;
+
+export const SearchContainer = styled.div<SearchProps>`
+  display: flex;
+  align-items: center;
+  position: absolute;
+  right: 0;
+  margin: 1rem;
+  padding: 0.5rem;
+  background-color: ${(props) =>
+    props.searchClicked ? "#F1F1F1" : "transparent"};
+  border-radius: 5rem;
+`;
+
+export const SearchIcon = styled.img`
+  width: 1rem;
+  height: 1rem;
+  cursor: pointer;
+`;
+
+export const SearchInput = styled.input<SearchProps>`
+  width: ${(props) => (props.searchClicked ? "17rem" : "0rem")};
+  margin: ${(props) => (props.searchClicked ? "0rem 0.5rem" : "0rem 0rem")};
+  background-color: transparent;
+  font-size: 1rem;
+  border: none;
+  outline: none;
+  transition: 2s;
+`;
+
+export const CloseIcon = styled.img<SearchProps>`
+  width: ${(props) => (props.searchClicked ? "0.7rem" : "0rem")};
+  height: ${(props) => (props.searchClicked ? "0.7rem" : "0rem")};
+  cursor: pointer;
+  transition: 0.3s;
+  transition-delay: 0.3s;
 `;
 
 export const PostContainer = styled.div`

--- a/src/container/found-board-container/styles.ts
+++ b/src/container/found-board-container/styles.ts
@@ -5,18 +5,52 @@ export const FoundBoardContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  width: 100vw;
+  height: 100%;
+`;
+
+export const CategoryContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   width: 100%;
-  height: 100vh;
+  height: 3rem;
+  padding: 0rem 2rem;
 `;
 
 export const Category = styled.div`
   display: flex;
   justify-content: center;
-  width: 100%;
-  height: 3rem;
   align-items: center;
   color: ${THEME_COLOR.DARK_VIOLET};
   font-size: 1.2rem;
   font-weight: bold;
-  border-bottom: 2px solid lightgray;
+`;
+
+export const PostContainer = styled.div`
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  padding: 0.4rem;
+  align-items: center;
+  background-color: ${THEME_COLOR.VIOLET};
+`;
+
+export const WriteButton = styled.div`
+  z-index: 100;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: fixed;
+  width: 3.7rem;
+  height: 3.7rem;
+  right: 0.7rem;
+  bottom: 0.7rem;
+  background-color: #353a5d;
+  border-radius: 50%;
+`;
+
+export const PlusIcon = styled.img`
+  width: 2rem;
+  height: 2rem;
 `;


### PR DESCRIPTION
### Issue Number

Close #6

### 작업 내용

- 배경 색상 적용
- 카드 형식으로 전체 레이아웃 변경
- post preview 안의 요소들 정렬 방식 수정
- 글 제목이 긴 경우, 말줄임표 적용
- 화면 우측 하단에 글 쓰기 버튼 추가
- 검색 버튼 추가
- 댓글 개수 및 이미지 미리 보기 추가

### 사진

<img width="189" alt="found-board-layout" src="https://user-images.githubusercontent.com/46309902/129382590-1b009725-e70c-4e1b-b17c-b80e1c21d738.PNG">

### 참고 사항

- 디자인은 계속해서 수정할 예정
- 데스크탑 버전을 위한 추가적인 레이아웃 디자인이 필요함
