### PR TITLE
분실물 게시판 레이아웃 구현 및 api 연결

### DIFF
--- a/src/common/endpoints.ts
+++ b/src/common/endpoints.ts
@@ -1,6 +1,7 @@
 const endpoints = {
   API_BASE_URL: "http://127.0.0.1:8000/api",
   FOUND_BOARD_API: "/found/board",
+  LOST_BOARD_API: "/lost/board",
 };
 
 export default endpoints;

--- a/src/common/lib/api/lost-board.ts
+++ b/src/common/lib/api/lost-board.ts
@@ -1,0 +1,14 @@
+import axios from "../axios";
+import endpoints from "../../endpoints";
+import { LostPostListModel } from "../../model/lost-post-list";
+
+const lostBoardAPI = {
+  getPostList: async (page: number): Promise<LostPostListModel> => {
+    const { data: postList } = await axios.get<LostPostListModel>(
+      `${endpoints.LOST_BOARD_API}/list?page_num=${page}`
+    );
+    return postList;
+  },
+};
+
+export default lostBoardAPI;

--- a/src/common/model/lost-post-list.ts
+++ b/src/common/model/lost-post-list.ts
@@ -1,0 +1,5 @@
+import { LostPostModel } from "../model/lost-post";
+
+export interface LostPostListModel {
+  data: LostPostModel[];
+}

--- a/src/common/model/lost-post.ts
+++ b/src/common/model/lost-post.ts
@@ -1,0 +1,12 @@
+export interface LostPostModel {
+  id: number;
+  title: string;
+  item_name: string;
+  lost_place: string;
+  content: string;
+  reply_num: number;
+  created_at: string;
+  changed_at: string;
+  user_id: number;
+  image_url: string;
+}

--- a/src/component/post-preview/index.tsx
+++ b/src/component/post-preview/index.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import * as S from "./styles";
 import { STATIC_URL } from "../../asset/constant";
-import { FoundPostPreviewProps } from "./types";
+import { PostPreviewProps } from "./types";
 
-const FoundPostPreview = (props: FoundPostPreviewProps) => {
+const PostPreview = (props: PostPreviewProps) => {
   const { title, item, location, image, replyCount } = props;
   return (
-    <S.FoundPostPreview>
+    <S.PostPreview>
       <S.TitleContainer>
         <S.Title>{title}</S.Title>
         <S.ReplyContainer>
@@ -26,8 +26,8 @@ const FoundPostPreview = (props: FoundPostPreviewProps) => {
         </S.ItemInfo>
         {image && <S.Image src={image} />}
       </S.Contents>
-    </S.FoundPostPreview>
+    </S.PostPreview>
   );
 };
 
-export default FoundPostPreview;
+export default PostPreview;

--- a/src/component/post-preview/styles.ts
+++ b/src/component/post-preview/styles.ts
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { THEME_COLOR } from "../../asset/constant";
 
-export const FoundPostPreview = styled.div`
+export const PostPreview = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-evenly;

--- a/src/component/post-preview/styles.ts
+++ b/src/component/post-preview/styles.ts
@@ -86,5 +86,4 @@ export const Location = styled.div`
 export const Image = styled.img`
   height: 3.5rem;
   width: 3.5rem;
-  /* margin-right: 1rem; */
 `;

--- a/src/component/post-preview/types.ts
+++ b/src/component/post-preview/types.ts
@@ -1,4 +1,4 @@
-export interface FoundPostPreviewProps {
+export interface PostPreviewProps {
   title: string;
   item: string;
   location: string;

--- a/src/container/found-board-container/index.tsx
+++ b/src/container/found-board-container/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import * as S from "./styles";
-import FoundPostPreview from "../../component/found-post-preview";
+import PostPreview from "../../component/post-preview";
 import foundBoardAPI from "../../common/lib/api/found-board";
 import { FoundPostModel } from "../../common/model/found-post";
 import { STATIC_URL } from "../../asset/constant";
@@ -46,7 +46,7 @@ const FoundBoardContainer = () => {
           data.map((post, idx) => {
             const { title, item_name, get_place, reply_num, image_url } = post;
             return (
-              <FoundPostPreview
+              <PostPreview
                 key={idx}
                 title={title}
                 item={item_name}

--- a/src/container/lost-board-container/index.tsx
+++ b/src/container/lost-board-container/index.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from "react";
+import * as S from "./styles";
+import PostPreview from "../../component/post-preview";
+import lostBoardAPI from "../../common/lib/api/lost-board";
+import { LostPostModel } from "../../common/model/lost-post";
+import { STATIC_URL } from "../../asset/constant";
+
+const LostBoardContainer = () => {
+  const [page, setPage] = useState(1);
+  const [data, setData] = useState([] as LostPostModel[]);
+  const [searchClicked, setSearchClicked] = useState(false);
+
+  const getPostList = async (page: number) => {
+    const result = await lostBoardAPI.getPostList(page);
+    const data = result.data;
+    setData(data);
+  };
+
+  const toggleSearch = () => {
+    setSearchClicked(!searchClicked);
+  };
+
+  useEffect(() => {
+    getPostList(page);
+  }, [page]);
+
+  return (
+    <S.LostBoardContainer>
+      <S.CategoryContainer>
+        <S.Category searchClicked={searchClicked}>분실물</S.Category>
+        <S.SearchContainer searchClicked={searchClicked}>
+          <S.SearchIcon src={STATIC_URL.SEARCH} onClick={toggleSearch} />
+          <S.SearchInput
+            searchClicked={searchClicked}
+            placeholder="검색어를 입력해 주세요"
+          />
+          <S.CloseIcon
+            searchClicked={searchClicked}
+            src={STATIC_URL.CLOSE}
+            onClick={toggleSearch}
+          />
+        </S.SearchContainer>
+      </S.CategoryContainer>
+      <S.PostContainer>
+        {data &&
+          data.map((post, idx) => {
+            const { title, item_name, lost_place, reply_num, image_url } = post;
+            return (
+              <PostPreview
+                key={idx}
+                title={title}
+                item={item_name}
+                location={lost_place}
+                replyCount={reply_num}
+                image={image_url}
+              />
+            );
+          })}
+        <S.WriteButton>
+          <S.PlusIcon src={STATIC_URL.WHITE_PLUS_ICON} />
+        </S.WriteButton>
+      </S.PostContainer>
+    </S.LostBoardContainer>
+  );
+};
+
+export default LostBoardContainer;

--- a/src/container/lost-board-container/styles.ts
+++ b/src/container/lost-board-container/styles.ts
@@ -1,0 +1,95 @@
+import styled from "styled-components";
+import { THEME_COLOR } from "../../asset/constant";
+
+export const LostBoardContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100vw;
+  height: 100%;
+`;
+
+export const CategoryContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 3rem;
+  padding: 0rem 1rem;
+`;
+
+interface SearchProps {
+  searchClicked: boolean;
+}
+
+export const Category = styled.div<SearchProps>`
+  display: flex;
+  color: ${THEME_COLOR.DARK_VIOLET};
+  font-size: 1.2rem;
+  font-weight: bold;
+  transition-delay: 0.3s;
+`;
+
+export const SearchContainer = styled.div<SearchProps>`
+  display: flex;
+  align-items: center;
+  position: absolute;
+  right: 0;
+  margin: 1rem;
+  padding: 0.5rem;
+  background-color: ${(props) =>
+    props.searchClicked ? "#F1F1F1" : "transparent"};
+  border-radius: 5rem;
+`;
+
+export const SearchIcon = styled.img`
+  width: 1rem;
+  height: 1rem;
+  cursor: pointer;
+`;
+
+export const SearchInput = styled.input<SearchProps>`
+  width: ${(props) => (props.searchClicked ? "17rem" : "0rem")};
+  margin: ${(props) => (props.searchClicked ? "0rem 0.5rem" : "0rem 0rem")};
+  background-color: transparent;
+  font-size: 1rem;
+  border: none;
+  outline: none;
+  transition: 2s;
+`;
+
+export const CloseIcon = styled.img<SearchProps>`
+  width: ${(props) => (props.searchClicked ? "0.7rem" : "0rem")};
+  height: ${(props) => (props.searchClicked ? "0.7rem" : "0rem")};
+  cursor: pointer;
+  transition: 0.3s;
+  transition-delay: 0.3s;
+`;
+
+export const PostContainer = styled.div`
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  padding: 0.4rem;
+  align-items: center;
+  background-color: ${THEME_COLOR.VIOLET};
+`;
+
+export const WriteButton = styled.div`
+  z-index: 100;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: fixed;
+  width: 3.7rem;
+  height: 3.7rem;
+  right: 0.7rem;
+  bottom: 0.7rem;
+  background-color: #353a5d;
+  border-radius: 50%;
+`;
+
+export const PlusIcon = styled.img`
+  width: 2rem;
+  height: 2rem;
+`;

--- a/src/view/lost-board/index.tsx
+++ b/src/view/lost-board/index.tsx
@@ -1,9 +1,10 @@
 import React from "react";
+import LostBoardContainer from "../../container/lost-board-container/index";
 
 const LostBoard = () => {
   return (
     <>
-      <div>Lost Board</div>
+      <LostBoardContainer />
     </>
   );
 };


### PR DESCRIPTION
### Issue Number

Close #4

### 작업 내용

- found-post-preview 폴더와 내부 파일들의 이름을 post-preview로 변경 (분실물 & 습득물 게시판에서의 중복 사용을 위해)
- 분실물 게시판 레이아웃
- 분실물 게시판의 전체 게시물 리스트를 가져오는 api 연결

### 사진

<img width="200" alt="lost-board" src="https://user-images.githubusercontent.com/46309902/131698206-c880ca18-e1c8-4e07-ba53-5b6642a0ce8a.PNG"> 
