### PR TITLE
분실물 업로드 페이지 레이아웃

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
+    "react-select": "^4.3.1",
     "styled-components": "^5.3.0",
     "typescript": "^4.2.3",
     "web-vitals": "^1.1.1"
@@ -46,6 +47,7 @@
   },
   "devDependencies": {
     "@types/react-router-dom": "^5.1.7",
+    "@types/react-select": "^4.0.17",
     "@types/styled-components": "^5.1.10",
     "babel-plugin-styled-components": "^1.12.0"
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import Layout from "../src/component/common/layout";
 import MainPage from "../src/view/main/index";
 import Notice from "../src/view/notice/index";
 import LostBoard from "../src/view/lost-board/index";
+import LostUpload from "../src/view/lost-upload";
 import FoundBoard from "../src/view/found-board/index";
 import Login from "../src/view/login/index";
 
@@ -17,6 +18,7 @@ const App: React.FC = () => (
           <Route path="/" exact component={MainPage} />
           <Route path="/notice" exact component={Notice} />
           <Route path="/lost-board" exact component={LostBoard} />
+          <Route path="/lost-board/upload" exact component={LostUpload} />
           <Route path="/found-board" exact component={FoundBoard} />
           <Route path="/login" exact component={Login} />
           <Redirect from="*" to="/" />

--- a/src/asset/constant.ts
+++ b/src/asset/constant.ts
@@ -22,4 +22,7 @@ export const STATIC_URL = {
   BACK_BUTTON: `https://user-images.githubusercontent.com/50616334/119186114-99127200-bab2-11eb-999b-5ba29212960f.png`,
   PHOTO: `https://user-images.githubusercontent.com/50616334/119203057-26fb5680-bacd-11eb-9735-ce91154a9815.png`,
   PHOTO_WHITE: `https://user-images.githubusercontent.com/50616334/119206697-e1dc2200-bad6-11eb-9b09-5e784a7fd72d.png`,
+  CAMERA: `https://user-images.githubusercontent.com/50616334/131724701-679fdcde-df00-40de-bd74-c9df11966278.png`,
+  X_MARK: `https://user-images.githubusercontent.com/50616334/131725487-3380d77a-3d24-4822-bc3a-b8f02283a5b1.png`,
+  X_MARK_WHITE: `https://user-images.githubusercontent.com/50616334/131726258-50e42b72-e282-43cb-9e53-a2371018e0cc.png`,
 };

--- a/src/asset/constant.ts
+++ b/src/asset/constant.ts
@@ -19,4 +19,7 @@ export const STATIC_URL = {
   WARN: `https://user-images.githubusercontent.com/46309902/119188852-3ae78e00-bab6-11eb-9781-246121926a09.png`,
   LOCATION: `https://user-images.githubusercontent.com/46309902/119208441-2965ac80-badd-11eb-963d-323f1d829af1.png`,
   ITEM: `https://user-images.githubusercontent.com/46309902/119210128-a09f3e80-bae5-11eb-9ca6-0c7aff8b3a41.png`,
+  BACK_BUTTON: `https://user-images.githubusercontent.com/50616334/119186114-99127200-bab2-11eb-999b-5ba29212960f.png`,
+  PHOTO: `https://user-images.githubusercontent.com/50616334/119203057-26fb5680-bacd-11eb-9735-ce91154a9815.png`,
+  PHOTO_WHITE: `https://user-images.githubusercontent.com/50616334/119206697-e1dc2200-bad6-11eb-9b09-5e784a7fd72d.png`,
 };

--- a/src/component/item-select-box/index.tsx
+++ b/src/component/item-select-box/index.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react";
 import Select from "react-select";
+import { THEME_COLOR } from "../../asset/constant";
 
 const ItemSelectBox = ()  => {
   const options = useMemo(
@@ -14,7 +15,21 @@ const ItemSelectBox = ()  => {
   return (
       <>
       <Select 
-        style={{width: `100%`}}
+        maxMenuHeight = {110}
+        placeholder="Select"
+        styles={{
+          option: (provided, state) => ({
+            ...provided,
+            color: state.isSelected ? 'white' : 'grayer',
+            backgroundColor: state.isSelected ? `${THEME_COLOR.VIOLET}` : 'white',
+          }),
+          control: (base, state) => ({
+              ...base,
+              '&:hover': { borderColor: 'gray'}, // border style on hover
+              border: '1px solid lightgray', // default border color
+              boxShadow: 'none', // no box-shadow
+          }),
+        }}
         options={options}/>
       </>
   );

--- a/src/component/item-select-box/index.tsx
+++ b/src/component/item-select-box/index.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo } from "react";
 import Select from "react-select";
 import { THEME_COLOR } from "../../asset/constant";
+import { ItemSelectBoxProps } from "./types";
 
-const ItemSelectBox = ()  => {
+const ItemSelectBox= (props: ItemSelectBoxProps)  => {
   const options = useMemo(
     () => [
       { value: "악세서리", label: "악세서리" },
@@ -16,7 +17,7 @@ const ItemSelectBox = ()  => {
       <>
       <Select 
         maxMenuHeight = {110}
-        placeholder="Select"
+        placeholder={props.placeholder}
         styles={{
           option: (provided, state) => ({
             ...provided,

--- a/src/component/item-select-box/index.tsx
+++ b/src/component/item-select-box/index.tsx
@@ -1,0 +1,23 @@
+import React, { useMemo } from "react";
+import Select from "react-select";
+
+const ItemSelectBox = ()  => {
+  const options = useMemo(
+    () => [
+      { value: "악세서리", label: "악세서리" },
+      { value: "전자기기", label: "전자기기" },
+      { value: "가방", label: "가방" },
+      { value: "기타 물품", label: "기타 물품" },
+    ],
+    []
+  );
+  return (
+      <>
+      <Select 
+        style={{width: `100%`}}
+        options={options}/>
+      </>
+  );
+}
+
+export default ItemSelectBox;

--- a/src/component/item-select-box/types.ts
+++ b/src/component/item-select-box/types.ts
@@ -1,0 +1,3 @@
+export interface ItemSelectBoxProps {
+  placeholder: string;
+}

--- a/src/component/photo-uploader/index.tsx
+++ b/src/component/photo-uploader/index.tsx
@@ -1,0 +1,48 @@
+import React, { useRef, useState } from "react";
+import { STATIC_URL } from "../../asset/constant";
+import * as S from "./styles";
+
+
+const PhotoUploader = (props: any) => {
+
+  // Create a reference to the hidden file input element
+  const hiddenFileInput = useRef<any>(null);
+  
+  // Programatically click the hidden file input element
+  // when the Button component is clicked
+  const handleClick = (event: any) => {
+    hiddenFileInput.current.click();
+  };
+
+  // Call a function (passed as a prop from the parent component)
+  // to handle the user-selected file 
+  const handleChange = (event: any) => {
+    const fileUploaded = event.target.files[0];
+    props.handleFile(fileUploaded);
+  };
+  return (
+    <>
+      <S.PhotoContainer>
+        <S.AddPhoto onClick={handleClick}>
+          <S.Photo src={STATIC_URL.PHOTO} alt="photo"/>
+        </S.AddPhoto>
+        <S.PhotoPreview>
+          <S.Delete src={STATIC_URL.X_MARK_WHITE} alt="delete"/>
+        </S.PhotoPreview>
+        <S.PhotoPreview>
+          <S.Delete src={STATIC_URL.X_MARK_WHITE} alt="delete"/>
+        </S.PhotoPreview>
+      </S.PhotoContainer>
+      <input
+        type="file"
+        accept="image/jpg, image/jpeg, image/png"
+        multiple
+        ref={hiddenFileInput}
+        onChange={handleChange}
+        style={{display: 'none'}}
+      />
+    </>
+  );
+}
+
+export default PhotoUploader;

--- a/src/component/photo-uploader/index.tsx
+++ b/src/component/photo-uploader/index.tsx
@@ -1,9 +1,30 @@
 import React, { useRef, useState } from "react";
 import { STATIC_URL } from "../../asset/constant";
 import * as S from "./styles";
+import { Photo } from "./types";
 
 
 const PhotoUploader = (props: any) => {
+  const [ photoList, setPhotoList] = useState<Photo[]>([]);
+
+  const photoPreview = () => {
+    return photoList.map((photo) => {
+      return (
+        <S.PhotoPreview>
+          <S.Delete 
+            src={STATIC_URL.X_MARK_WHITE} 
+            alt="delete"
+            onClick={() => removePhoto(photo.url)}
+          />
+          <S.Photo src={photo.url} alt="file to add"/>
+        </S.PhotoPreview>
+      )
+    })
+  }
+
+  const removePhoto = (deleteUrl: string) => {
+    setPhotoList(photoList.filter(photo => photo.url !== deleteUrl))
+  }
 
   // Create a reference to the hidden file input element
   const hiddenFileInput = useRef<any>(null);
@@ -16,29 +37,30 @@ const PhotoUploader = (props: any) => {
 
   // Call a function (passed as a prop from the parent component)
   // to handle the user-selected file 
-  const handleChange = (event: any) => {
-    const fileUploaded = event.target.files[0];
-    props.handleFile(fileUploaded);
+  const handlePhoto = (e: any) => {
+    let temp = Array<Photo>();
+    const photoToAdd = e.target.files;
+
+    for (let i = 0; i < photoToAdd.length; i++) {
+      temp.push({id: photoToAdd[i].name, file: photoToAdd[i], url: URL.createObjectURL(photoToAdd[i])})
+    };
+    setPhotoList(temp.concat(photoList));
   };
+
   return (
     <>
       <S.PhotoContainer>
         <S.AddPhoto onClick={handleClick}>
-          <S.Photo src={STATIC_URL.PHOTO} alt="photo"/>
+          <S.PhotoIcon src={STATIC_URL.PHOTO} alt="photo"/>
         </S.AddPhoto>
-        <S.PhotoPreview>
-          <S.Delete src={STATIC_URL.X_MARK_WHITE} alt="delete"/>
-        </S.PhotoPreview>
-        <S.PhotoPreview>
-          <S.Delete src={STATIC_URL.X_MARK_WHITE} alt="delete"/>
-        </S.PhotoPreview>
+        {photoPreview()}
       </S.PhotoContainer>
       <input
         type="file"
         accept="image/jpg, image/jpeg, image/png"
         multiple
         ref={hiddenFileInput}
-        onChange={handleChange}
+        onChange={(e) => handlePhoto(e)}
         style={{display: 'none'}}
       />
     </>

--- a/src/component/photo-uploader/styles.ts
+++ b/src/component/photo-uploader/styles.ts
@@ -18,7 +18,6 @@ export const AddPhoto = styled.div`
   min-width: 6.5rem;
   height: 6.5rem;
   background-color: ${THEME_COLOR.GRAY};
-  border: 1px dashed black;
   margin: 0.3rem 0.3rem;
 `;
 
@@ -49,4 +48,25 @@ export const Delete = styled.img`
   
   position: absolute;
   right: 0px;
+`;
+
+export const UploadContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.5rem;
+  height: 3.5rem;
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  background-color: ${THEME_COLOR.VIOLET};
+  color: white;
+  border-radius: 1.3rem;
+  z-index: 100;
+`;
+
+export const UploadButton = styled.img`
+  width: 1.8rem;
+  height: 1.8rem;
+  z-index: 100;
 `;

--- a/src/component/photo-uploader/styles.ts
+++ b/src/component/photo-uploader/styles.ts
@@ -6,39 +6,47 @@ export const Button = styled.button`
 
 export const PhotoContainer = styled.div`
   display: flex;
+  flex-flow: wrap;
   align-items: center;
-  justify-content: space-between;
   width: 100%;
-
 `;
 
 export const AddPhoto = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 6.5rem;
+  min-width: 6.5rem;
   height: 6.5rem;
   background-color: ${THEME_COLOR.GRAY};
   border: 1px dashed black;
+  margin: 0.3rem 0.3rem;
 `;
 
 export const PhotoPreview = styled.div`
   display: flex;
   align-items: flex-start;
   justify-content: flex-end;
+  position: relative;
   width: 6.5rem;
   height: 6.5rem;
-  background-color: ${THEME_COLOR.VIOLET};
+  margin: 0.3rem 0.3rem;
+`;
+
+export const PhotoIcon = styled.img`
+  width: 1.8rem;
+  height: 1.8rem;
 `;
 
 export const Photo = styled.img`
-  width: 1.8rem;
-  height: 1.8rem;
+  width: 6.5rem;
+  height: 6.5rem;
 `;
 
 export const Delete = styled.img`
   width: 1rem;
   height: 1rem;
   margin: 0.2rem;
-  z-index: 100;
+  
+  position: absolute;
+  right: 0px;
 `;

--- a/src/component/photo-uploader/styles.ts
+++ b/src/component/photo-uploader/styles.ts
@@ -1,0 +1,44 @@
+import styled from "styled-components";
+import { THEME_COLOR } from "../../asset/constant";
+
+export const Button = styled.button`
+`;
+
+export const PhotoContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+
+`;
+
+export const AddPhoto = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 6.5rem;
+  height: 6.5rem;
+  background-color: ${THEME_COLOR.GRAY};
+  border: 1px dashed black;
+`;
+
+export const PhotoPreview = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  width: 6.5rem;
+  height: 6.5rem;
+  background-color: ${THEME_COLOR.VIOLET};
+`;
+
+export const Photo = styled.img`
+  width: 1.8rem;
+  height: 1.8rem;
+`;
+
+export const Delete = styled.img`
+  width: 1rem;
+  height: 1rem;
+  margin: 0.2rem;
+  z-index: 100;
+`;

--- a/src/component/photo-uploader/types.ts
+++ b/src/component/photo-uploader/types.ts
@@ -1,0 +1,5 @@
+export interface Photo {
+  id: string;
+  file: string;
+  url: string;
+}

--- a/src/component/place-select-box/index.tsx
+++ b/src/component/place-select-box/index.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo } from "react";
 import Select from "react-select";
 import { THEME_COLOR } from "../../asset/constant";
+import { PlaceSelectBoxProps } from "./types";
 
-const PlaceSelectBox = ()  => {
+const PlaceSelectBox = (props: PlaceSelectBoxProps)  => {
   const options = useMemo(
     () => [
       { value: "하나스퀘어", label: "하나스퀘어" },
@@ -17,7 +18,7 @@ const PlaceSelectBox = ()  => {
       <>
       <Select 
         maxMenuHeight = {110}
-        placeholder="Select"
+        placeholder={props.placeholder}
         styles={{
           option: (provided, state) => ({
             ...provided,

--- a/src/component/place-select-box/index.tsx
+++ b/src/component/place-select-box/index.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react";
 import Select from "react-select";
+import { THEME_COLOR } from "../../asset/constant";
 
 const PlaceSelectBox = ()  => {
   const options = useMemo(
@@ -11,10 +12,25 @@ const PlaceSelectBox = ()  => {
     ],
     []
   );
+
   return (
       <>
       <Select 
-        style={{width: `100%`}}
+        maxMenuHeight = {110}
+        placeholder="Select"
+        styles={{
+          option: (provided, state) => ({
+            ...provided,
+            color: state.isSelected ? 'white' : 'grayer',
+            backgroundColor: state.isSelected ? `${THEME_COLOR.VIOLET}` : 'white',
+          }),
+          control: (base, state) => ({
+              ...base,
+              '&:hover': { borderColor: 'gray'}, // border style on hover
+              border: '1px solid lightgray', // default border color
+              boxShadow: 'none', // no box-shadow
+          }),
+        }}
         options={options}/>
       </>
   );

--- a/src/component/place-select-box/index.tsx
+++ b/src/component/place-select-box/index.tsx
@@ -1,0 +1,23 @@
+import React, { useMemo } from "react";
+import Select from "react-select";
+
+const PlaceSelectBox = ()  => {
+  const options = useMemo(
+    () => [
+      { value: "하나스퀘어", label: "하나스퀘어" },
+      { value: "과학도서관", label: "과학도서관" },
+      { value: "애기능생활관", label: "애기능생활관" },
+      { value: "우정정보관", label: "우정정보관" },
+    ],
+    []
+  );
+  return (
+      <>
+      <Select 
+        style={{width: `100%`}}
+        options={options}/>
+      </>
+  );
+}
+
+export default PlaceSelectBox;

--- a/src/component/place-select-box/types.ts
+++ b/src/component/place-select-box/types.ts
@@ -1,0 +1,3 @@
+export interface PlaceSelectBoxProps {
+  placeholder: string;
+}

--- a/src/component/upload-header/index.tsx
+++ b/src/component/upload-header/index.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import * as S from "./styles";
+import { STATIC_URL } from "../../asset/constant";
+
+const UploadHeader = () => {
+  return (
+    <>
+      <S.MobileHeader>
+        <S.BackIcon src={STATIC_URL.BACK_BUTTON} alt="back" />
+        <S.Title>글 쓰기</S.Title>
+        <S.SubmitButton>완료</S.SubmitButton>
+      </S.MobileHeader>
+    </>
+  );
+};
+
+export default UploadHeader;

--- a/src/component/upload-header/index.tsx
+++ b/src/component/upload-header/index.tsx
@@ -7,8 +7,8 @@ const UploadHeader = () => {
     <>
       <S.MobileHeader>
         <S.BackIcon src={STATIC_URL.BACK_BUTTON} alt="back" />
-        <S.Title>글 쓰기</S.Title>
-        <S.SubmitButton>완료</S.SubmitButton>
+        <S.Title>글쓰기</S.Title>
+        <S.SubmitButton>등록</S.SubmitButton>
       </S.MobileHeader>
     </>
   );

--- a/src/component/upload-header/styles.ts
+++ b/src/component/upload-header/styles.ts
@@ -1,0 +1,47 @@
+import styled from "styled-components/macro";
+import { THEME_COLOR, BREAKPOINT } from "../../asset/constant";
+
+export const MobileHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  height: 4rem;
+  padding: 0rem 1rem;
+
+  position: fixed;
+  top: 0;
+  z-index: 100;
+  background-color: white;
+  border-bottom: 0.5px solid ${THEME_COLOR.GRAYER};
+  @media only screen and (min-width: ${BREAKPOINT}px) {
+    display: none;
+  }
+`;
+
+export const Title = styled.div`
+  font-size: 1.2rem;
+  font-weight: bold;
+`;
+
+export const BackIcon = styled.img`
+  width: 1.1rem;
+  height: 1.1rem;
+  opacity: 0.7;
+`;
+
+export const SubmitButton = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  
+  width: 2.7rem;
+  height: 1.7rem;
+
+  padding: 0.2rem;
+  border-radius: 0.6rem;
+
+  font-size: 1rem;
+  color: white;
+  background-color: ${THEME_COLOR.VIOLET};
+`;

--- a/src/component/upload-header/styles.ts
+++ b/src/component/upload-header/styles.ts
@@ -41,7 +41,7 @@ export const SubmitButton = styled.div`
   padding: 0.2rem;
   border-radius: 0.6rem;
 
-  font-size: 1rem;
-  color: white;
-  background-color: ${THEME_COLOR.VIOLET};
+  font-size: 1.1rem;
+  color: ${THEME_COLOR.VIOLET};
+  font-weight: bolder;
 `;

--- a/src/container/lost-upload-container/index.tsx
+++ b/src/container/lost-upload-container/index.tsx
@@ -3,6 +3,7 @@ import { STATIC_URL } from "../../asset/constant";
 import UploadHeader from "../../component/upload-header";
 import ItemSelectBox from "../../component/item-select-box";
 import PlaceSelectBox from "../../component/place-select-box";
+import PhotoUploader from "../../component/photo-uploader";
 import * as S from "./styles";
 
 const LostUploadContainer = () => {
@@ -34,6 +35,7 @@ const LostUploadContainer = () => {
               사진 첨부
             </S.PhotoContainer>
           </label>
+          <PhotoUploader/>
         </S.UploadContainer>
     </S.Wrapper>
   );

--- a/src/container/lost-upload-container/index.tsx
+++ b/src/container/lost-upload-container/index.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { STATIC_URL } from "../../asset/constant";
+import UploadHeader from "../../component/upload-header";
+import ItemSelectBox from "../../component/item-select-box";
+import PlaceSelectBox from "../../component/place-select-box";
+import * as S from "./styles";
+
+const LostUploadContainer = () => {
+  return (
+    <S.Wrapper>
+      <UploadHeader/>
+      <S.UploadContainer>
+        <S.TitleContainer>
+          <S.Title>제목</S.Title>
+          <S.InputBox/>
+        </S.TitleContainer>
+        <S.ItemContainer>
+          <S.TypeContainer>
+              <S.SubText>분실물</S.SubText>
+              <ItemSelectBox/>
+          </S.TypeContainer>
+          <S.TypeContainer>
+              <S.SubText>분실 장소</S.SubText>
+              <PlaceSelectBox/>
+          </S.TypeContainer>
+        </S.ItemContainer>
+        <S.ContentBox placeholder="내용을 입력해 주세요"/>
+        <label>
+          <S.ImageInput
+            type="file"
+            accept="image/jpeg, image/jpg, image/png, image/gif"
+          />
+          <S.PhotoContainer>
+            <S.Photo src={STATIC_URL.PHOTO_WHITE} alt="photo"/>
+            사진 첨부
+          </S.PhotoContainer>
+        </label>
+      </S.UploadContainer>
+    </S.Wrapper>
+  );
+};
+
+export default LostUploadContainer;

--- a/src/container/lost-upload-container/index.tsx
+++ b/src/container/lost-upload-container/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { STATIC_URL } from "../../asset/constant";
 import UploadHeader from "../../component/upload-header";
 import ItemSelectBox from "../../component/item-select-box";
 import PlaceSelectBox from "../../component/place-select-box";
@@ -25,16 +24,6 @@ const LostUploadContainer = () => {
             <S.InputBox placeholder="제목을 입력해 주세요."/>
           </S.TitleContainer>
           <S.ContentBox placeholder="내용을 입력해 주세요."/>
-          <label>
-            <S.ImageInput
-              type="file"
-              accept="image/jpeg, image/jpg, image/png, image/gif"
-            />
-            <S.PhotoContainer>
-              <S.Photo src={STATIC_URL.PHOTO_WHITE} alt="photo"/>
-              사진 첨부
-            </S.PhotoContainer>
-          </label>
           <PhotoUploader/>
         </S.UploadContainer>
     </S.Wrapper>

--- a/src/container/lost-upload-container/index.tsx
+++ b/src/container/lost-upload-container/index.tsx
@@ -10,10 +10,6 @@ const LostUploadContainer = () => {
     <S.Wrapper>
       <UploadHeader/>
         <S.UploadContainer>
-          <S.TitleContainer>
-            <S.Title>제목</S.Title>
-            <S.InputBox/>
-          </S.TitleContainer>
           <S.ItemContainer>
             <S.TypeContainer>
                 <S.SubText>분실물</S.SubText>
@@ -24,7 +20,10 @@ const LostUploadContainer = () => {
                 <PlaceSelectBox/>
             </S.TypeContainer>
           </S.ItemContainer>
-          <S.ContentBox placeholder="내용을 입력해 주세요"/>
+          <S.TitleContainer>
+            <S.InputBox placeholder="제목을 입력해 주세요."/>
+          </S.TitleContainer>
+          <S.ContentBox placeholder="내용을 입력해 주세요."/>
           <label>
             <S.ImageInput
               type="file"

--- a/src/container/lost-upload-container/index.tsx
+++ b/src/container/lost-upload-container/index.tsx
@@ -12,12 +12,10 @@ const LostUploadContainer = () => {
         <S.UploadContainer>
           <S.ItemContainer>
             <S.TypeContainer>
-                <S.SubText>분실물</S.SubText>
-                <ItemSelectBox/>
+                <ItemSelectBox placeholder="분실물"/>
             </S.TypeContainer>
             <S.TypeContainer>
-                <S.SubText>분실 장소</S.SubText>
-                <PlaceSelectBox/>
+                <PlaceSelectBox placeholder="분실 장소"/>
             </S.TypeContainer>
           </S.ItemContainer>
           <S.TitleContainer>

--- a/src/container/lost-upload-container/index.tsx
+++ b/src/container/lost-upload-container/index.tsx
@@ -9,33 +9,33 @@ const LostUploadContainer = () => {
   return (
     <S.Wrapper>
       <UploadHeader/>
-      <S.UploadContainer>
-        <S.TitleContainer>
-          <S.Title>제목</S.Title>
-          <S.InputBox/>
-        </S.TitleContainer>
-        <S.ItemContainer>
-          <S.TypeContainer>
-              <S.SubText>분실물</S.SubText>
-              <ItemSelectBox/>
-          </S.TypeContainer>
-          <S.TypeContainer>
-              <S.SubText>분실 장소</S.SubText>
-              <PlaceSelectBox/>
-          </S.TypeContainer>
-        </S.ItemContainer>
-        <S.ContentBox placeholder="내용을 입력해 주세요"/>
-        <label>
-          <S.ImageInput
-            type="file"
-            accept="image/jpeg, image/jpg, image/png, image/gif"
-          />
-          <S.PhotoContainer>
-            <S.Photo src={STATIC_URL.PHOTO_WHITE} alt="photo"/>
-            사진 첨부
-          </S.PhotoContainer>
-        </label>
-      </S.UploadContainer>
+        <S.UploadContainer>
+          <S.TitleContainer>
+            <S.Title>제목</S.Title>
+            <S.InputBox/>
+          </S.TitleContainer>
+          <S.ItemContainer>
+            <S.TypeContainer>
+                <S.SubText>분실물</S.SubText>
+                <ItemSelectBox/>
+            </S.TypeContainer>
+            <S.TypeContainer>
+                <S.SubText>분실 장소</S.SubText>
+                <PlaceSelectBox/>
+            </S.TypeContainer>
+          </S.ItemContainer>
+          <S.ContentBox placeholder="내용을 입력해 주세요"/>
+          <label>
+            <S.ImageInput
+              type="file"
+              accept="image/jpeg, image/jpg, image/png, image/gif"
+            />
+            <S.PhotoContainer>
+              <S.Photo src={STATIC_URL.PHOTO_WHITE} alt="photo"/>
+              사진 첨부
+            </S.PhotoContainer>
+          </label>
+        </S.UploadContainer>
     </S.Wrapper>
   );
 };

--- a/src/container/lost-upload-container/styles.ts
+++ b/src/container/lost-upload-container/styles.ts
@@ -24,27 +24,20 @@ export const TitleContainer = styled.div`
   align-items: center;
   justify-content: center;
 
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
 
-`;
-
-export const Title = styled.div`
-  width: 100%;
-  font-size: 1rem;
-  font-weight: bold;
-  margin-bottom: 0.3rem;
 `;
 
 export const InputBox = styled.input`
   width: 100%;
-  height: 1.8rem;
+  height: 2.2rem;
 
   font-size: 1rem;
   outline: none;
 
   border: 1px solid ${THEME_COLOR.GRAYER};
-  border-radius: 0.5rem;
-  padding: 0.2rem;
+  border-radius: 0.1rem;
+  padding: 0.5rem;
 
 `;
 
@@ -69,24 +62,6 @@ export const SubText = styled.div`
   font-weight: bold;
   margin-right: 0.5rem;
   margin-bottom: 0.5rem;
-
-`;
-
-export const TypeOptions = styled.select`
-  width: 6.2rem;
-  height: 1.5rem;
-
-  font-size: 1rem;
-  color: ${THEME_COLOR.VIOLET};
-
-  border: 1px solid ${THEME_COLOR.VIOLET};
-  border-radius: 0.5rem;
-
-  padding: 0.1rem;
-`;
-
-export const Option = styled.option`
-  border: 1px solid ${THEME_COLOR.LIGHT_VIOLET};
 `;
 
 export const ContentBox = styled.textarea`
@@ -103,8 +78,8 @@ export const ContentBox = styled.textarea`
   outline: none;
 
   border: 1px solid ${THEME_COLOR.GRAYER};
-  border-radius: 0.5rem;
-  padding: 0.2rem;
+  border-radius: 0.2rem;
+  padding: 0.5rem;
   margin-bottom: 1rem;
 
 `;
@@ -155,7 +130,6 @@ export const ImageButton = styled.button`
 `;
 
 export const PhotoContainer = styled.div`
-  /* width: 100%; */
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/container/lost-upload-container/styles.ts
+++ b/src/container/lost-upload-container/styles.ts
@@ -4,7 +4,6 @@ import { THEME_COLOR } from "../../asset/constant";
 export const Wrapper = styled.div`
   display: flex;
   width: 100%;
-  min-width: 380px;
   flex-direction: column;
   justify-content: center;
   align-items: center;

--- a/src/container/lost-upload-container/styles.ts
+++ b/src/container/lost-upload-container/styles.ts
@@ -32,22 +32,14 @@ export const Title = styled.div`
   width: 100%;
   font-size: 1rem;
   font-weight: bold;
-  /* border-bottom: 0.1rem solid ${THEME_COLOR.VIOLET}; */
   margin-bottom: 0.3rem;
-
 `;
 
 export const InputBox = styled.input`
-  /* display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center; */
-
   width: 100%;
   height: 1.8rem;
 
   font-size: 1rem;
-  /* resize: vertical; */
   outline: none;
 
   border: 1px solid ${THEME_COLOR.GRAYER};
@@ -58,24 +50,16 @@ export const InputBox = styled.input`
 
 export const ItemContainer = styled.div`
   width: 100%;
-
   display: flex;
   flex-direction: row;
   align-items: center;
-  /* justify-content: space-between; */
-  
   margin-bottom: 1rem;
-
 `;
 
 export const TypeContainer = styled.div`
   display: flex;
   flex-direction: column;
-  /* align-items: center; */
-  /* justify-content: space-between; */
   width: 50%;
-  /* padding-right: 0.4rem; */
-
   margin: 0rem 0.4rem 0rem 0rem;
 
 `;
@@ -83,8 +67,8 @@ export const TypeContainer = styled.div`
 export const SubText = styled.div`
   font-size: 1rem;
   font-weight: bold;
-  /* border-bottom: 0.1rem solid ${THEME_COLOR.VIOLET}; */
   margin-right: 0.5rem;
+  margin-bottom: 0.5rem;
 
 `;
 
@@ -99,12 +83,10 @@ export const TypeOptions = styled.select`
   border-radius: 0.5rem;
 
   padding: 0.1rem;
-
 `;
 
 export const Option = styled.option`
   border: 1px solid ${THEME_COLOR.LIGHT_VIOLET};
-
 `;
 
 export const ContentBox = styled.textarea`
@@ -188,7 +170,6 @@ export const PhotoContainer = styled.div`
   margin: 0rem 1rem 3rem 0rem;
   font-size: 0.8rem;
   font-weight: bold;
-  /* border: 1px solid black; */
 `;
 
 export const Photo = styled.img`

--- a/src/container/lost-upload-container/styles.ts
+++ b/src/container/lost-upload-container/styles.ts
@@ -12,7 +12,7 @@ export const Wrapper = styled.div`
 export const UploadContainer = styled.div`
   display: flex;
   flex-direction: column;
-  width: 100%;
+  width: 375px;
   padding: 0.8rem 1rem;
 `;
 

--- a/src/container/lost-upload-container/styles.ts
+++ b/src/container/lost-upload-container/styles.ts
@@ -1,0 +1,200 @@
+import styled from "styled-components";
+import { THEME_COLOR } from "../../asset/constant";
+
+export const Wrapper = styled.div`
+  display: flex;
+  width: 100%;
+  min-width: 380px;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const UploadContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: 0.8rem 1rem;
+`;
+
+export const TitleContainer = styled.div`
+  width: 100%;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  margin-bottom: 1rem;
+
+`;
+
+export const Title = styled.div`
+  width: 100%;
+  font-size: 1rem;
+  font-weight: bold;
+  /* border-bottom: 0.1rem solid ${THEME_COLOR.VIOLET}; */
+  margin-bottom: 0.3rem;
+
+`;
+
+export const InputBox = styled.input`
+  /* display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center; */
+
+  width: 100%;
+  height: 1.8rem;
+
+  font-size: 1rem;
+  /* resize: vertical; */
+  outline: none;
+
+  border: 1px solid ${THEME_COLOR.GRAYER};
+  border-radius: 0.5rem;
+  padding: 0.2rem;
+
+`;
+
+export const ItemContainer = styled.div`
+  width: 100%;
+
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  /* justify-content: space-between; */
+  
+  margin-bottom: 1rem;
+
+`;
+
+export const TypeContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  /* align-items: center; */
+  /* justify-content: space-between; */
+  width: 50%;
+  /* padding-right: 0.4rem; */
+
+  margin: 0rem 0.4rem 0rem 0rem;
+
+`;
+
+export const SubText = styled.div`
+  font-size: 1rem;
+  font-weight: bold;
+  /* border-bottom: 0.1rem solid ${THEME_COLOR.VIOLET}; */
+  margin-right: 0.5rem;
+
+`;
+
+export const TypeOptions = styled.select`
+  width: 6.2rem;
+  height: 1.5rem;
+
+  font-size: 1rem;
+  color: ${THEME_COLOR.VIOLET};
+
+  border: 1px solid ${THEME_COLOR.VIOLET};
+  border-radius: 0.5rem;
+
+  padding: 0.1rem;
+
+`;
+
+export const Option = styled.option`
+  border: 1px solid ${THEME_COLOR.LIGHT_VIOLET};
+
+`;
+
+export const ContentBox = styled.textarea`
+  display: block;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  width: 100%;
+  height: 20rem;
+
+  font-size: 1rem;
+  resize: vertical;
+  outline: none;
+
+  border: 1px solid ${THEME_COLOR.GRAYER};
+  border-radius: 0.5rem;
+  padding: 0.2rem;
+  margin-bottom: 1rem;
+
+`;
+
+export const ImageInput = styled.input`
+  display: none;
+`;
+
+export const ImageBox = styled.div`
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+
+  width: 100%;
+  font-size: 1.4rem;
+  height: 30rem;
+
+  outline: none;
+  border: 1px solid ${THEME_COLOR.GRAYER};
+  background-color: white;
+
+  border-radius: 0.7rem;
+  margin-top: 2rem;
+  padding: 0.8rem 2rem;
+`;
+
+export const ImageButton = styled.button`
+
+  width: 4.5rem;
+  height: 2rem;
+  margin: 0.3rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  outline: none;
+  border: none;
+  border-radius: 0.5rem;
+
+  background-color: ${THEME_COLOR.VIOLET};
+  color: white;
+  box-shadow: 3px 3px 3px 3px ${THEME_COLOR.GRAYER};
+
+  font-size: 0.8rem;
+  cursor: pointer;
+`;
+
+export const PhotoContainer = styled.div`
+  /* width: 100%; */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 6.4rem;
+  height: 2.5rem;
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  background-color: ${THEME_COLOR.VIOLET};
+  color: white;
+  border-radius: 0.7rem;
+  margin: 0rem 1rem 3rem 0rem;
+  font-size: 0.8rem;
+  font-weight: bold;
+  /* border: 1px solid black; */
+`;
+
+export const Photo = styled.img`
+  width: 1.8rem;
+  height: 1.8rem;
+  z-index: 100%;
+  margin-right: 0.5rem;
+`;

--- a/src/view/lost-upload/index.tsx
+++ b/src/view/lost-upload/index.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import LostUploadContainer from "../../container/lost-upload-container";
+
+const LostUpload = () => {
+  return (
+    <>
+      <LostUploadContainer />
+    </>
+  );
+};
+
+export default LostUpload;


### PR DESCRIPTION
### Issue Number

Close #10

### 작업 내용

- 분실물 작성 페이지 레이아웃 완성
- 분실물, 습득물 게시글 작성 공통 헤더
- 분실물, 습득물 공통 Select Box
- 분실 장소, 습득 장소, 보관 장소 공통 Select Box
- 사진 업로드 & 삭제 & 미리보기 기능 구현 

### 사진

![image](https://user-images.githubusercontent.com/50616334/131880186-449b6582-cc8d-487c-8cda-be6218f05460.png)


### 참고 사항

- 분실물 작성 페이지에서는 분실물과 분실 장소 총 2가지의 Select Box가 필요했는데 습득물 작성 페이지에서는 습득물, 습득 장소, 보관 장소 3가지의 Select Box를 어떤 식으로 배치할지 디자인 필요
- 데스크탑 버전을 위한 추가적인 레이아웃 디자인이 필요함
- 더 좋은 디자인 아이디어 있으면 언제든 환영 ^_^
